### PR TITLE
Add ignored URL config file

### DIFF
--- a/src/ignoredUrls.json
+++ b/src/ignoredUrls.json
@@ -1,0 +1,10 @@
+[
+  "sada",
+  "feminino",
+  "uncategorized",
+  "ex-cruzeiro",
+  "campeonato",
+  "apostas",
+  "adversarios",
+  "samuca-tv"
+]

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,23 @@ const HOME_URL = "https://www.centraldatoca.com.br/";
 // Caminho do arquivo que armazenará as URLs processadas
 const processedNewsFilePath = path.resolve(__dirname, 'processedNews.json');
 
+// Caminho do arquivo com filtros de URLs que devem ser ignoradas
+const ignoreUrlsFilePath = path.resolve(__dirname, 'ignoredUrls.json');
+
+// Carrega os filtros a partir do arquivo
+let ignoreUrls: string[] = [];
+if (fs.existsSync(ignoreUrlsFilePath)) {
+  try {
+    const data = fs.readFileSync(ignoreUrlsFilePath, 'utf-8').trim();
+    if (data) {
+      ignoreUrls = JSON.parse(data);
+    }
+  } catch (err) {
+    console.error('Erro ao ler ignoredUrls.json. Nenhum filtro será aplicado.', err);
+    ignoreUrls = [];
+  }
+}
+
 // Carrega as URLs processadas do arquivo (para evitar envios duplicados)
 let processedNews = new Set<string>();
 if (fs.existsSync(processedNewsFilePath)) {
@@ -91,7 +108,7 @@ async function runDeepseek(prompt: string): Promise<string> {
 
 // Função para verificar se uma URL deve ser ignorada (por exemplo, notícias da Sada)
 function shouldIgnoreUrl(url: string): boolean {
-  return url.includes('/sada/') || url.includes('/feminino/') || url.includes('/uncategorized/') || url.includes('/ex-cruzeiro/') || url.includes('/campeonato/');
+  return ignoreUrls.some(segment => url.includes(`/${segment}/`));
 }
 
 // Função que realiza o scraping do site e extrai as notícias com o resumo completo


### PR DESCRIPTION
## Summary
- store ignored URL segments in `ignoredUrls.json`
- load ignore list from file without defaults in code
- check URLs with leading/trailing slashes

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c9e8b188332a926c73d52b931e8