### PR TITLE
Fix path for JSON configuration files

### DIFF
--- a/src/ignoredUrls.json
+++ b/src/ignoredUrls.json
@@ -1,0 +1,10 @@
+[
+  "sada",
+  "feminino",
+  "uncategorized",
+  "ex-cruzeiro",
+  "campeonato",
+  "apostas",
+  "adversarios",
+  "samuca-tv"
+]


### PR DESCRIPTION
## Summary
- ensure `ignoredUrls.json` and `processedNews.json` are read from `src` even when running from `dist`
- refactor ignore list loading logic into a helper function

## Testing
- `pnpm run build`
- `pnpm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c9e8b188332a926c73d52b931e8