### PR TITLE
Fix startup when processedNews.json missing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   centraldatoca:
     build: .

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,35 +43,19 @@ function loadIgnoreUrls(): string[] {
 
 const ignoreUrls = loadIgnoreUrls();
 
-// Caminho do arquivo com filtros de URLs que devem ser ignoradas
-const ignoreUrlsFilePath = path.resolve(__dirname, 'ignoredUrls.json');
-
-// Carrega os filtros a partir do arquivo
-let ignoreUrls: string[] = [];
-if (fs.existsSync(ignoreUrlsFilePath)) {
-  try {
-    const data = fs.readFileSync(ignoreUrlsFilePath, 'utf-8').trim();
-    if (data) {
-      ignoreUrls = JSON.parse(data);
-    }
-  } catch (err) {
-    console.error('Erro ao ler ignoredUrls.json. Nenhum filtro será aplicado.', err);
-    ignoreUrls = [];
-  }
-}
-
 // Carrega as URLs processadas do arquivo (para evitar envios duplicados)
 let processedNews = new Set<string>();
-if (fs.existsSync(processedNewsFilePath)) {
+try {
+  if (!fs.existsSync(processedNewsFilePath) || fs.lstatSync(processedNewsFilePath).isDirectory()) {
+    fs.writeFileSync(processedNewsFilePath, '[]');
+  }
   const data = fs.readFileSync(processedNewsFilePath, 'utf-8').trim();
   if (data) {
-    try {
-      processedNews = new Set(JSON.parse(data));
-    } catch (err) {
-      console.error('Erro ao fazer parse do arquivo processedNews.json. Iniciando com um conjunto vazio.', err);
-      processedNews = new Set();
-    }
+    processedNews = new Set(JSON.parse(data));
   }
+} catch (err) {
+  console.error('Erro ao ler processedNews.json. Iniciando com um conjunto vazio.', err);
+  processedNews = new Set();
 }
 
 // Função para salvar as URLs processadas no arquivo


### PR DESCRIPTION
## Summary
- initialize `processedNews.json` when missing so Node doesn't try to read a directory

## Testing
- `npm run build`
- `pnpm exec tsc`
- `docker compose build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685da548403883329973f1a9084fada4